### PR TITLE
Charts with axis_labels do not display in gmail

### DIFF
--- a/lib/gchart.rb
+++ b/lib/gchart.rb
@@ -249,8 +249,10 @@ class Gchart
   end
   
   def self.jstize(string)
+    # See http://github.com/mattetti/googlecharts/issues#issue/27
+    URI.escape( string )
     # See discussion: http://github.com/mattetti/googlecharts/commit/9b5cfb93aa51aae06611057668e631cd515ec4f3#comment_51347
-    string.gsub(' ', '+').gsub(/\[|\{|\}|\\|\^|\[|\]|\`|\]/) {|c| "%#{c[0].to_s.upcase}"}
+    # string.gsub(' ', '+').gsub(/\[|\{|\}|\\|\^|\[|\]|\`|\]/) {|c| "%#{c[0].to_s.upcase}"}
     # string.gsub(' ', '+').gsub(/\[|\{|\}|\||\\|\^|\[|\]|\`|\]/) {|c| "%#{c[0].to_s.upcase}"}
   end    
   # load all the custom aliases


### PR DESCRIPTION
Displaying a chart in Gmail does not work with the current jstize function. It seems that Gmail chokes on unescaped | (pipe) characters for a labelled line chart, prefering the URL-encoded version. If jstize is replaced with URI.escape, then the chart renders correctly in Gmail.

The discussion for 9b5cfb93aa51aae06611 makes it seem like this is intentional. However, URI.escape does not seem to break the display of any of the other example charts listed on http://googlecharts.rubyforge.org/
