### PR TITLE
Fix axis_range broken in line chart problem

### DIFF
--- a/lib/gchart.rb
+++ b/lib/gchart.rb
@@ -466,8 +466,6 @@ class Gchart
 
     return unless set && set.respond_to?(:each) && set.find {|o| o}.respond_to?(:each)
 
-    # in the case of a line graph, the first axis range should 1
-    index_increase = type.to_s == 'line' ? 1 : 0
     'chxr=' + set.enum_for(:each_with_index).map do |axis_range, index|
       next nil if axis_range.nil? # ignore this axis
       min, max, step = axis_range
@@ -475,7 +473,7 @@ class Gchart
         max = axis_range.last
         step = nil
       end
-      [(index + index_increase), (min_value || min || 0), (max_value || max), step].compact.join(',')
+      [index, (min_value || min || 0), (max_value || max), step].compact.join(',')
     end.compact.join("|")
   end
 


### PR DESCRIPTION
I am trying to fix the issue 15
http://github.com/mattetti/googlecharts/issues/#issue/15

I found that axis index also begins at 0 in line chart. 
Refer to example of Google Chart API 
http://code.google.com/intl/zh-TW/apis/chart/docs/gallery/line_charts.html#axis_range

I' am not very sure, please check if I am right?
Thank you. 
