### PR TITLE
Add theme option to GChart.new

### DIFF
--- a/lib/gchart.rb
+++ b/lib/gchart.rb
@@ -73,6 +73,10 @@ class Gchart
   end
 
   def initialize(options={})
+    # Start with theme defaults if a theme is set
+    theme = options[:theme]
+    options = theme ? Chart::Theme.load(theme).to_options.merge(options) : options
+    options.delete(:theme)
     @type = options[:type] || 'line'
     @data = []
     @width = 300


### PR DESCRIPTION
This allow a theme options to be passed when doing GChart.new. Before it xas only possible to use it with GChart.some_chart_type construct.
Use the same code as in GChart.some_chart_type method
