### PR TITLE
Addind 'overlapping' option to bar charts

### DIFF
--- a/lib/gchart.rb
+++ b/lib/gchart.rb
@@ -38,7 +38,7 @@ class Gchart
     'chart.png'
   end
 
-  attr_accessor :title, :type, :width, :height, :curved, :horizontal, :grouped, :legend, :legend_position, :labels, :data, :encoding, :bar_colors,
+  attr_accessor :title, :type, :width, :height, :curved, :horizontal, :grouped, :overlapping, :legend, :legend_position, :labels, :data, :encoding, :bar_colors,
   :title_color, :title_size, :title_alignment, :custom, :axis_with_labels, :axis_labels, :bar_width_and_spacing, :id, :alt, :klass,
   :range_markers, :geographical_area, :map_colors, :country_codes, :axis_range, :filename, :min, :max, :colors, :usemap
 
@@ -85,6 +85,7 @@ class Gchart
     @curved = false
     @horizontal = false
     @grouped = false
+    @overlapping = false
     @use_ssl = false
     @encoding = 'simple'
     # @max_value = 'auto'
@@ -132,6 +133,13 @@ class Gchart
 
   # Sets the bar graph presentation (stacked or grouped)
   def stacked=(option=true)
+    @overlapping = false
+    @grouped = option ? false : true
+  end
+  
+  # Sets the bar graph presentation (overlapping or grouped)
+  def overlapping=(option=true)
+    @overlapping = option
     @grouped = option ? false : true
   end
 
@@ -524,7 +532,7 @@ class Gchart
     when 'radar'
       "r" + (curved? ? 's' : '')
     when 'bar'
-      "b" + (horizontal? ? "h" : "v") + (grouped? ? "g" : "s")
+      "b" + (horizontal? ? "h" : "v") + (grouped? ? "g" : (overlapping? ? "o" : "s"))
     end
   end
 

--- a/lib/gchart/aliases.rb
+++ b/lib/gchart/aliases.rb
@@ -10,6 +10,7 @@ class Gchart
   alias_method :slice_colors=, :bar_colors=
   alias_method :horizontal?, :horizontal
   alias_method :grouped?, :grouped
+  alias_method :overlapping?, :overlapping
   alias_method :curved?, :curved
 
 end

--- a/spec/gchart_spec.rb
+++ b/spec/gchart_spec.rb
@@ -307,11 +307,13 @@ describe "a bar graph" do
     Gchart.bar.should include('cht=bvs')
   end
 
-  it "should be able to stacked or grouped" do
+  it "should be able to stacked, grouped or overlapping" do
     Gchart.bar(:stacked => true).should include('cht=bvs')
     Gchart.bar(:stacked => false).should include('cht=bvg')
     Gchart.bar(:grouped => true).should include('cht=bvg')
     Gchart.bar(:grouped => false).should include('cht=bvs')
+    Gchart.bar(:overlapping => true).should include('cht=bvo')
+    Gchart.bar(:overlapping => false).should include('cht=bvg')
   end
 
   it "should be able to have different bar colors" do


### PR DESCRIPTION
Hi there,

bar charts can be stacked or grouped but they can also be overlapping. Please see documentation for reference:
http://code.google.com/apis/chart/image/docs/gallery/bar_charts.html

I added the option (overlapping) which will enable just that. Setting overlapping to false will make the chart grouped, similarly to stacked => false.

It would be great if you could please pull it to master.

Cheers,
Marcin
