### PR TITLE
URL update

### DIFF
--- a/lib/gchart.rb
+++ b/lib/gchart.rb
@@ -14,7 +14,7 @@ class Gchart
     if use_ssl
       'https://chart.googleapis.com/chart?'
     else
-      'http://chart.apis.google.com/chart?'
+      'http://chart.googleapis.com/chart?'
     end
   end
 

--- a/spec/gchart_spec.rb
+++ b/spec/gchart_spec.rb
@@ -32,7 +32,7 @@ describe "generating a default Gchart" do
   end
 
   it "should include the Google URL" do
-    @chart.should include("http://chart.apis.google.com/chart?")
+    @chart.should include("http://chart.googleapis.com/chart?")
   end
 
   it "should have a default size" do


### PR DESCRIPTION
The old `chart.apis.google.com` URL stopped working a few days ago.  This change causes `chart.googleapi.com` to be used for both `http` and `https`
