### PR TITLE
Add pie_c type for concentric pie charts.

### DIFF
--- a/lib/gchart.rb
+++ b/lib/gchart.rb
@@ -19,7 +19,7 @@ class Gchart
   end
 
   def self.types
-    @types ||= ['line', 'line_xy', 'scatter', 'bar', 'venn', 'pie', 'pie_3d', 'jstize', 'sparkline', 'meter', 'map', 'radar']
+    @types ||= ['line', 'line_xy', 'scatter', 'bar', 'venn', 'pie', 'pie_3d', 'pie_c', 'jstize', 'sparkline', 'meter', 'map', 'radar']
   end
 
   def self.simple_chars
@@ -528,6 +528,7 @@ class Gchart
     when 'line'      then "lc"
     when 'line_xy'   then "lxy"
     when 'pie_3d'    then "p3"
+    when 'pie_c'     then "pc"
     when 'pie'       then "p"
     when 'venn'      then "v"
     when 'scatter'   then "s"

--- a/spec/gchart_spec.rb
+++ b/spec/gchart_spec.rb
@@ -227,6 +227,12 @@ describe "generating different type of charts" do
     expect(Gchart.pie).to include('cht=p')
   end
 
+  it "should be able to generate a Concentric Pie Chart" do
+    expect(Gchart.pie_c).to be_an_instance_of(String)
+    expect(Gchart.pie_c).to include('cht=pc')
+    expect(Gchart.pie_c(size: '240x240', data: [[-1], [2,3]])).to include('-1|1,2,3')
+  end
+
   it "should be able to generate a Google-O-Meter" do
     expect(Gchart.meter).to be_an_instance_of(String)
     expect(Gchart.meter).to include('cht=gom')


### PR DESCRIPTION
Adding the 'pc' type seems to be a seamless drop in of the concentric pie chart.