### PR TITLE
Use the HTTPS URL by default

### DIFF
--- a/lib/gchart.rb
+++ b/lib/gchart.rb
@@ -10,7 +10,7 @@ require 'enumerator'
 class Gchart
   include GchartInfo
 
-  def self.url(use_ssl = false)
+  def self.url(use_ssl = true)
     if use_ssl
       'https://chart.googleapis.com/chart?'
     else
@@ -88,7 +88,7 @@ class Gchart
     @grouped = false
     @overlapped = false
 
-    @use_ssl = false
+    @use_ssl = true
     @encoding = 'simple'
     # @max_value = 'auto'
     # @min_value defaults to nil meaning zero

--- a/spec/gchart_spec.rb
+++ b/spec/gchart_spec.rb
@@ -31,8 +31,8 @@ describe "generating a default Gchart" do
     expect(@chart).to include("chtt=title\nsubtitle")
   end
 
-  it "should include the Google URL" do
-    expect(@chart).to include("http://chart.apis.google.com/chart?")
+  it "should include the HTTPS Google URL" do
+    expect(@chart).to include("https://chart.googleapis.com/chart?")
   end
 
   it "should have a default size" do


### PR DESCRIPTION
Fixes https://github.com/mattetti/googlecharts/issues/81

cc @zukunftsalick
